### PR TITLE
Fix KeyError on `res` argument passed to `runner_on_ok`

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -124,7 +124,7 @@ class CallbackModule(object):
 
     def runner_on_ok(self, host, res):
         # Only send an event when the task has changed on the host
-        if res['changed']:
+        if res.get('changed'):
             event_text = "$$$\n{0}[{1}]\n$$$\n".format(res['invocation']['module_name'], res['invocation']['module_args'])
             self.send_task_event(
                 'Ansible task changed on "{0}"'.format(host),


### PR DESCRIPTION
Use a more conservative approach as to the existence of the `changed`
key.

This could be extended to all the keys that are used on dicts passed
to the callback (as afaik Ansible doesn't provide any guarantee of their
existence), but for now a case-by-case approach may be enough.