### PR TITLE
Handle no_log: True and missing invocation key gracefully

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -115,7 +115,7 @@ class CallbackModule(object):
     # format helper for event_text
     @staticmethod
     def format_result(res):
-        msg = "$$$\n{0}\n$$$\n".format(res.get('msg'))
+        msg = "$$$\n{0}\n$$$\n".format(res['msg']) if res.get('msg') else ""
         module_name = 'undefined'
 
         if res.get('censored'):

--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -110,8 +110,6 @@ class CallbackModule(object):
 
         return "{0} {1}s".format(number, noun)
 
-    ### Ansible callbacks ###
-
     # format helper for event_text
     @staticmethod
     def format_result(res):
@@ -129,6 +127,7 @@ class CallbackModule(object):
 
         return event_text, module_name
 
+    ### Ansible callbacks ###
     def runner_on_failed(self, host, res, ignore_errors=False):
         event_text, module_name = self.format_result(res)
         self.send_task_event(


### PR DESCRIPTION
Task example for no_log: True. Leads to missing invocation key as well.

```
- name: create new secret
  shell: openssl rand -base64 32
  register: my_secret
  no_log: true
```

Value of result:

```
{'censored': 'results hidden due to no_log parameter', 'changed': True, 'rc': 0}
```

Cheers :beers: 

Daniel
