### PR TITLE
Set log level for datadog agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+# 2.2.0 / 2017-12-27
+- [FEATURE] Set log level to warning for the datadog and request packages. See [#24][] (thanks to @n0ts)
+
 # 2.1.0 / 2017-12-26
 - [FEATURE] Disable callback if required python packages aren't installed. See [#28][] (thanks to @dobber)
 


### PR DESCRIPTION
Hi, I use ansible datadog_callback.yml plugin.

Usually plugin output datadog-agent's info level to ansible.log.
Like this.

```
2017-06-12 16:16:54,344 requests.packages.urllib3.connectionpool https://app.datadoghq.com:443 "POST /api/v1/events?api_key=key HTTP/1.1" 202 336
2017-06-12 16:16:54,344 datadog.api 202 POST https://app.datadoghq.com/api/v1/events (673.3ms)
```

I fixed output only warning level.


Thanks,