### PR TITLE
Fixing a typo in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ api_key: <your-api-key>
 You can specify a custom location for the configuration file using the
 `ANSIBLE_DATADOG_CALLBACK_CONF_FILE` environment file.
 
-For exemple:
+For example:
 ```
 ANSIBLE_DATADOG_CALLBACK_CONF_FILE=/etc/datadog/callback_conf.yaml ansible-playbook ...
 ```


### PR DESCRIPTION
Found a small typo in the README file. Fixed it.