### PR TITLE
Enumerate loaded hosts and check for datadog_api_key in their vars

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -241,7 +241,14 @@ class CallbackModule(CallbackBase):
                 self.disabled = True
             else:
                 try:
-                    api_key = hostvars['localhost']['datadog_api_key']
+                    found_hostvars_datadog_api_key = False
+                    for host in hostvars.keys():
+                        if 'datadog_api_key' in  hostvars[host]:
+                            api_key = hostvars[host]['datadog_api_key']
+                            found_hostvars_datadog_api_key = True
+                            break
+                    if not found_hostvars_datadog_api_key:
+                        api_key = hostvars['localhost']['host_datadog_api_key']
                 except Exception as e:
                     print('No "api_key" found in the config file ({0}) and "datadog_api_key" is not set in the hostvars: disabling Datadog callback plugin'.format(config_path))
                     self.disabled = True


### PR DESCRIPTION
The datadog_api_key var is only checked if it is set for localhost. Which didn't really fit an inventory with multistage environment such as https://www.digitalocean.com/community/tutorials/how-to-manage-multistage-environments-with-ansible where we don't want to log dev runs.

I expected to be able to define it in group_vars, not sure if it's the _right_ way, since it's a callback plugin that needs to be defined on the host that runs the playbook only.