### PR TITLE
Added loader argument for yaml.load

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -56,7 +56,7 @@ class CallbackModule(CallbackBase):
         conf_dict = {}
         if os.path.isfile(file_path):
             with open(file_path, 'r') as conf_file:
-                conf_dict = yaml.load(conf_file)
+                conf_dict = yaml.load(conf_file, Loader=yaml.FullLoader)
 
         api_key = os.environ.get('DATADOG_API_KEY', conf_dict.get('api_key', ''))
         dd_url = os.environ.get('DATADOG_URL', conf_dict.get('url', ''))


### PR DESCRIPTION
I was seeing this in my Ansible plays:
`YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`

Per https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation I added the Loader argument. 