### PR TITLE
cast api_key as str in datadog.initialize

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -277,7 +277,7 @@ class CallbackModule(CallbackBase):
 
         # Set up API client and send a start event
         if not self.disabled:
-            datadog.initialize(api_key=api_key, api_host=dd_url)
+            datadog.initialize(api_key=str(api_key), api_host=dd_url)
 
             self.send_playbook_event(
                 'Ansible play "{0}" started in playbook "{1}" by "{2}" against "{3}"'.format(


### PR DESCRIPTION
When using a vaulted variable the API key is returned with the type: ansible.parsing.yaml.objects.AnsibleVaultEncryptedUnicode ([ref](https://github.com/ansible/ansible/blob/devel/lib/ansible/parsing/yaml/objects.py#L86)), where as datadogpy expects the type: String ([ref](https://github.com/DataDog/datadogpy/blob/058114cc3d65483466684c96a5c23e36c3aa052e/datadog/__init__.py#L51-L52)). The result is that the API fails to parse the Ansible type and the following (403) error is returned by API:

```
{
    "status": "error",
    "code": 403,
    "errors": [
        "Forbidden"
    ],
    "statuspage": "http://status.datadoghq.com",
    "twitter": "http://twitter.com/datadogops",
    "email": "support@datadoghq.com"
}
```

While the `AnsibleVaultEncryptedUnicode` can not be a considered a String most common python string actions will now work as expected ([ref](https://github.com/ansible/ansible/commit/9667f221a59ff95aa9104dd6a9a13976e29a7146)). Casting the API key to a String before it is used to initialise datadogpy seems to resolve the issue where the API returns 403.

=> Relevant test on Ansible Repo:
https://github.com/ansible/ansible/blob/4856ab0e681f799ed4f893a34deb6a50e6d2400e/test/units/config/test_manager.py#L147-L157