### PR TITLE
Cast api_key from host_vars to str to support encrypted values

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -260,7 +260,7 @@ class CallbackModule(CallbackBase):
                 self.disabled = True
             else:
                 try:
-                    api_key = hostvars['localhost']['datadog_api_key']
+                    api_key = str(hostvars['localhost']['datadog_api_key'])
                     if not dd_url:
                         dd_url = hostvars['localhost'].get('datadog_url')
                     if not dd_site:


### PR DESCRIPTION
For an encrypted host_var, the class of the object changes from
ansible.parsing.yaml.objects.AnsibleUnicode to ansible.parsing.yaml.objects.AnsibleVaultEncryptedUnicode
As a result, the api_key is not injected correctly. Casting to str solves the problem