### PR TITLE
Remove extraneous call of hostname conversion

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -339,7 +339,6 @@ class CallbackModule(CallbackBase):
             event_title += ' with errors'
             event_text += "\nErrors occurred on the following hosts:\n%%%\n"
             for host, failures, unreachable in error_hosts:
-                host = self.get_dd_hostname(host)
                 event_text += "- `{0}` (failure: {1}, unreachable: {2})\n".format(
                     host,
                     failures,


### PR DESCRIPTION
`error_hosts` already contains converted hostnames, so don't call `get_dd_hostname` on it again.