### PR TITLE
Replace @ in events to avoid notifying @mentions

### DIFF
--- a/datadog_callback.py
+++ b/datadog_callback.py
@@ -82,7 +82,7 @@ class CallbackModule(CallbackBase):
         try:
             datadog.api.Event.create(
                 title=title,
-                text=text,
+                text=text.replace('@','(@)'), # avoid notifying @ mentions
                 alert_type=alert_type,
                 priority=priority,
                 tags=tags,


### PR DESCRIPTION
When using Ansible to create Datadog monitors, the events we create here
could contain @mentions meant to appear in the monitor message. When
an event contains an @mention, Datadog notifies the team @mentioned.
This could cause teams to be notified or paged when the monitor is created.

This replaces @mentions with (@)mentions, preventing the notification.