### PR TITLE
requirements.txt: sort entries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 datadog
-pyyaml>=3.10
 packaging
+pyyaml>=3.10


### PR DESCRIPTION
It is good practice to keep entries in requirements.txt sorted.

No functional change.