### PR TITLE
chore(codeowners): update barx to agent-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @DataDog/agent-build-and-releases
+*   @DataDog/agent-delivery


### PR DESCRIPTION
This PR updates the codeowners to the updated team name Agent Delivery
