### PR TITLE
chore(github): reduce workflow token permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,8 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
[JIRA-510](https://datadoghq.atlassian.net/browse/BARX-510)

Github token permissions should follow the [least privilege principle](https://datadoghq.atlassian.net/wiki/x/TIVE6Q)

[JIRA-510]: https://datadoghq.atlassian.net/browse/JIRA-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ