### PR TITLE
Update CODEOWNERS to remove agent-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @DataDog/container-ecosystems @DataDog/agent-delivery
+*   @DataDog/container-ecosystems


### PR DESCRIPTION
Removed @DataDog/agent-delivery from CODEOWNERS.